### PR TITLE
Added rate limit option for subscribe

### DIFF
--- a/ocs-gateway/src/main/scala/ocs/gateway/EventMonitor.scala
+++ b/ocs-gateway/src/main/scala/ocs/gateway/EventMonitor.scala
@@ -1,19 +1,39 @@
 package ocs.gateway
 
 import akka.stream.scaladsl.Source
-import csw.event.api.scaladsl.{EventService, EventSubscription}
+import csw.event.api.scaladsl.{EventService, EventSubscription, SubscriptionModes}
 import csw.params.core.models.{Prefix, Subsystem}
 import csw.params.events.{Event, EventKey, EventName}
+import scala.concurrent.duration._
 
 class EventMonitor(eventService: EventService) {
-  def subscribe(subsystem: String, component: Option[String], event: Option[String]): Source[Event, EventSubscription] = {
+  /**
+   * Subscribes to events based on the given arguments.
+   *
+   * @param subsystem subsystem name
+   * @param component component name
+   * @param event event name
+   * @param rateLimit optional rate limit in ms (only used if event name is given)
+   */
+  def subscribe(subsystem: String,
+                component: Option[String],
+                event: Option[String],
+                rateLimit: Option[Int]): Source[Event, EventSubscription] = {
+    val subscriber = eventService.defaultSubscriber
     (component, event) match {
       case (Some(componentVal), Some(eventVal)) =>
-        eventService.defaultSubscriber.subscribe(Set(EventKey(Prefix(s"$subsystem.$componentVal"), EventName(eventVal))))
+        rateLimit match {
+          case None =>
+            subscriber.subscribe(Set(EventKey(Prefix(s"$subsystem.$componentVal"), EventName(eventVal))))
+          case Some(duration) =>
+            subscriber.subscribe(Set(EventKey(Prefix(s"$subsystem.$componentVal"), EventName(eventVal))),
+              duration.millis,
+              SubscriptionModes.RateLimiterMode)
+        }
       case (Some(componentVal), None) =>
-        eventService.defaultSubscriber.pSubscribe(Subsystem.withName(subsystem), s"$componentVal*")
+        subscriber.pSubscribe(Subsystem.withName(subsystem), s"$componentVal*")
       case _ =>
-        eventService.defaultSubscriber.pSubscribe(Subsystem.withName(subsystem), "*")
+        subscriber.pSubscribe(Subsystem.withName(subsystem), "*")
     }
   }
 }

--- a/ocs-gateway/src/main/scala/ocs/gateway/server/Routes.scala
+++ b/ocs-gateway/src/main/scala/ocs/gateway/server/Routes.scala
@@ -54,10 +54,10 @@ class Routes(
         } ~
         pathPrefix("events") {
           path("subscribe" / Segment) { subsystem =>
-            parameters(("component".?, "event".?)) { (component, event) =>
+            parameters(("component".?, "event".?, "rateLimit".?)) { (component, event, rateLimit) =>
               complete {
                 eventMonitor
-                  .subscribe(subsystem, component, event)
+                  .subscribe(subsystem, component, event, rateLimit.map(_.toInt))
                   .map(evt => ServerSentEvent(Json.stringify(Json.toJson(evt))))
                   .keepAlive(10.second, () => ServerSentEvent.heartbeat)
               }


### PR DESCRIPTION
I added a rate limit option for subscribe in Routes (Could be necessary to prevent web apps from being overloaded by too many events). I used this in csw-event-monitor and thought it should probably be available in esw-prototype as well, for future web apps that want to limit the speed of incoming events.